### PR TITLE
Use Update for bot logic instead of timers

### DIFF
--- a/installation_files/go.mod
+++ b/installation_files/go.mod
@@ -1,13 +1,15 @@
 module BotWars
 
-go 1.19
+go 1.21
+
+toolchain go1.22.4
 
 require (
-	github.com/noxworld-dev/noxscript/ns/v4 v4.12.0
-	github.com/noxworld-dev/opennox-lib v0.0.0-20230831140802-093df546a389
+	github.com/noxworld-dev/noxscript/ns/v4 v4.16.1
+	github.com/noxworld-dev/opennox-lib v0.0.0-20240106132033-e8abe68bd8d5
 )
 
 require (
-	golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63 // indirect
+	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/installation_files/go.sum
+++ b/installation_files/go.sum
@@ -1,9 +1,9 @@
-github.com/noxworld-dev/noxscript/ns/v4 v4.12.0 h1:gCXXD6ohT1Thx04jC/E2RdgourZ8CYurgOJ4KU9jqGg=
-github.com/noxworld-dev/noxscript/ns/v4 v4.12.0/go.mod h1:l8sd8BvVo6LjzYjzAr7V/nbBkp0B/UMQRWbVTq0U67A=
-github.com/noxworld-dev/opennox-lib v0.0.0-20230831140802-093df546a389 h1:2TGFssmSyB0Txmmi0TaZZECXTWPx4DUPrNBj0HfiM7g=
-github.com/noxworld-dev/opennox-lib v0.0.0-20230831140802-093df546a389/go.mod h1:lj1pzcq9aD1K0yMs3Qo1v6IpGnUvhRH9a2NaG8Wn9hE=
-golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63 h1:m64FZMko/V45gv0bNmrNYoDEq8U5YUhetc9cBWKS1TQ=
-golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63/go.mod h1:0v4NqG35kSWCMzLaMeX+IQrlSnVE/bqGSyC2cz/9Le8=
+github.com/noxworld-dev/noxscript/ns/v4 v4.16.1 h1:QFxwNL/I+DX/u2o6wVWxVeoRE9zqTzNr2O0Tw/eiYBA=
+github.com/noxworld-dev/noxscript/ns/v4 v4.16.1/go.mod h1:H6W25adFWdP6r95qVMThXMad0kgfyi6OncQmk1INecc=
+github.com/noxworld-dev/opennox-lib v0.0.0-20240106132033-e8abe68bd8d5 h1:py/Z0Illi3jZ9MaL9Dpq3wH9MC+s0H8OapZ1pvJH4nU=
+github.com/noxworld-dev/opennox-lib v0.0.0-20240106132033-e8abe68bd8d5/go.mod h1:liEd6wzKFZsgIOX76YGRZaAqhQjEcLzMwlHJ+qk0yoU=
+golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa h1:FRnLl4eNAQl8hwxVVC17teOw8kdjVDVAiFMtgUdTSRQ=
+golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa/go.mod h1:zk2irFbV9DP96SEBUUAy67IdHUaZuSnrz1n472HUCLE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/installation_files/timer.go
+++ b/installation_files/timer.go
@@ -1,0 +1,27 @@
+package BotWars
+
+import (
+	"time"
+
+	"github.com/noxworld-dev/noxscript/ns/v4"
+)
+
+type Updater struct {
+	last time.Duration
+}
+
+func (u *Updater) EachSec(sec float64, fnc func()) {
+	dt := time.Duration(sec * float64(time.Second))
+	now := ns.Now()
+	if u.last != 0 && u.last+dt < now {
+		return
+	}
+	u.last = now
+	fnc()
+}
+
+func (u *Updater) EachFrame(frame int, fnc func()) {
+	if ns.Frame()%frame == 0 {
+		fnc()
+	}
+}


### PR DESCRIPTION
Currently the bot script uses timer recursion for some of the logic. A function may execute some logic and then set a timer for itself.

Although this is perfectly valid, due to the way our script engine is implemented, this timer recursion grows the function stack indefinitely. Eventually it goes above the limit and the engine kills the map.

To prevent this, I added an `Updater` type that can be set for each of the functions. It should then be called inside bot's `Update` function with `EachSec` or `EachFrame`. Since `Update` is called every frame, and the updater checks the last time it was executed, the logic will still work the same way as with the timers.

This makes the script way more stable, however, it seems there are still a few similar issues left. I marked two more places that could cause this with `FIXME` comment. I was not sure if I can rewrite that without breaking the logic.

Also, turned out the OpenNox itself suffers from a similar issue. It will be fixed in the next release too. 